### PR TITLE
added dbw simulated CAN, removed the dataspeed joystick node

### DIFF
--- a/launch/ssc_joystick_sim.launch
+++ b/launch/ssc_joystick_sim.launch
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<launch>
+
+    <remap from="/diagnostics" to="/as/diagnostics" />
+
+    <remap from="/as/brake_cmd" to="/vehicle/brake_cmd" />
+    <remap from="/as/brake_info_report" to="/vehicle/brake_info_report" />
+    <remap from="/as/brake_report" to="/vehicle/brake_report" />
+    <remap from="/as/disable" to="/vehicle/disable" />
+    <remap from="/as/enable" to="/vehicle/enable" />
+    <remap from="/as/gps/fix" to="/vehicle/gps_fix"/>
+    <remap from="/as/steering_cmd" to="/vehicle/steering_cmd" />
+    <remap from="/as/steering_report" to="/vehicle/steering_report" />
+    <remap from="/as/surround_report" to="/vehicle/surround_report" />
+    <remap from="/as/throttle_cmd" to="/vehicle/throttle_cmd" />
+    <remap from="/as/throttle_report" to="/vehicle/throttle_report" />
+    <remap from="/as/turn_signal_cmd" to="/vehicle/turn_signal_cmd" />
+    <remap from="/as/gear_cmd" to="/vehicle/gear_cmd" />
+    <remap from="/as/gear_report" to="/vehicle/gear_report" />
+    <remap from="/as/wheel_speed_report" to="/vehicle/wheel_speed_report" />
+    <remap from="/as/adas_input" to="/vehicle/adas_input" />
+  
+<!-- Launch the simulated vehicle -->
+  <include file="$(find dbw_mkz_gazebo)/launch/dbw_mkz_gazebo.launch" >
+    <arg name="use_camera_control" value="true" />
+    <arg name="world_name" value="$(find dbw_mkz_gazebo)/worlds/box_world.world" />
+    <arg name="sim_param_file" value="$(find dbw_mkz_gazebo)/yaml/default_sim_params.yaml" />
+  </include>
+
+<!-- Launch the simulated vehicle CAN -->
+  <include file="$(find dbw_mkz_can)/launch/dbw.launch" >
+    <arg name="live" value="false" />
+    <arg name="load_urdf" value="false" />
+    <arg name="can_ns" value="can_bus_dbw" />
+  </include>
+
+<!-- SSC -->
+  <group ns="as">
+    <arg name="dev" default="/dev/input/js0" />
+    <node pkg="joy" type="joy_node" name="joystick">
+      <param name="dev" value="$(arg dev)" />
+      <param name="deadzone" value="0.01"/>
+      <param name="autorepeat_rate" value="50.0"/>
+    </node>
+
+    <node pkg="joystick_vehicle_test" type="joystick_vehicle_test" name="joystick_vehicle_test"
+      args="-f $(find joystick_vehicle_test)/joystick_vehicle_test.json" output="screen"/>
+
+    <node pkg="speed_model" type="speed_model" name="speed_model"
+      args="-f $(find speed_model)/core_speed_model/speed_model.json" output="screen"/>
+
+    <node pkg="steering_model" type="steering_model" name="steering_model"
+      args="-f $(find steering_model)/core_steering_model/steering_model.json" />
+
+    <node pkg="ds_veh_controller" type="ds_veh_controller" name="veh_controller"
+      args="-f $(find ds_veh_controller)/core_veh_controller/ds_veh_controller.json" />
+
+    <node pkg="ds_veh_controller" type="ds_veh_interface" name="veh_interface"
+      args="-f $(find ds_veh_controller)/core_veh_controller/ds_veh_interface.json" />
+    </group>
+
+</launch>
+
+
+


### PR DESCRIPTION
Tested by launching the single launch file.
Noticed some odd behavior initially on the terminal output, but
SSC/joystick_vehicle_test works as expected.