### PR TITLE
Maint/ci add release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   indigo:
     docker:
-      - image: autonomoustuff/docker-builds:indigo-ros-core
+      - image: autonomoustuff/docker-builds:indigo-ros-base
     steps:
       - checkout
       - run:
@@ -28,7 +28,7 @@ jobs:
 
   kinetic:
     docker:
-      - image: autonomoustuff/docker-builds:kinetic-ros-core
+      - image: autonomoustuff/docker-builds:kinetic-ros-base
     steps:
       - checkout
       - run:
@@ -54,7 +54,7 @@ jobs:
 
   lunar:
     docker:
-      - image: autonomoustuff/docker-builds:lunar-ros-core
+      - image: autonomoustuff/docker-builds:lunar-ros-base
     steps:
       - checkout
       - run:
@@ -80,7 +80,7 @@ jobs:
 
   melodic:
     docker:
-      - image: autonomoustuff/docker-builds:melodic-ros-core
+      - image: autonomoustuff/docker-builds:melodic-ros-base
     steps:
       - checkout
       - run:
@@ -106,7 +106,7 @@ jobs:
 
   indigo_release:
     docker:
-      - image: autonomoustuff/docker-builds:indigo-ros-core
+      - image: autonomoustuff/docker-builds:indigo-ros-base
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-llc -c trusty --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-ssc -c trusty --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
   kinetic_release:
@@ -149,7 +149,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-llc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-ssc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
   lunar_release:
@@ -173,7 +173,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-llc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-ssc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
   melodic_release:
@@ -197,7 +197,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-llc -c bionic --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-ssc -c bionic --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-repo -c trusty --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-llc -c trusty --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
   kinetic_release:
@@ -149,7 +149,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-repo -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-llc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
   lunar_release:
@@ -173,7 +173,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-repo -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-llc -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
   melodic_release:
@@ -197,7 +197,7 @@ jobs:
           name: Upload
           command: |
             cd ..
-            deb-s3 upload -b autonomoustuff-repo -c bionic --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+            deb-s3 upload -b autonomoustuff-llc -c bionic --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
     working_directory: ~/src
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,19 +205,19 @@ workflows:
   ros_build:
     jobs:
       - indigo:
-          filter:
+          filters:
             branches:
               ignore: release
       - kinetic:
-          filter:
+          filters:
             branches:
               ignore: release
       - lunar:
-          filter:
+          filters:
             branches:
               ignore: release
       - melodic:
-          filter:
+          filters:
             branches:
               ignore: release
   ros_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,13 @@ version: 2
 jobs:
   indigo:
     docker:
-      - image: ros:indigo-ros-core
+      - image: autonomoustuff/docker-builds:indigo-ros-core
     steps:
       - checkout
       - run:
           name: Set Up Container
           command: |
-            apt-get update -qq && apt-get install software-properties-common -y
-            add-apt-repository ppa:ubuntu-toolchain-r/test -y
-            apt-get update && apt-get install openssh-client python-catkin-tools build-essential curl gcc-5 g++-5 -y
-            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 1 --slave /usr/bin/g++ g++ /usr/bin/g++-5
-            curl https://s3.us-east-2.amazonaws.com/astuff-common-lib/ubuntu_1404/libas-common_2.1.0-0~14.040_amd64.deb -o /tmp/libas-common.deb
-            dpkg -i /tmp/libas-common.deb
+            apt-get update -qq
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep install --from-paths . --ignore-src -y
             cd ..
@@ -33,15 +28,13 @@ jobs:
 
   kinetic:
     docker:
-      - image: ros:kinetic-ros-core
+      - image: autonomoustuff/docker-builds:kinetic-ros-core
     steps:
       - checkout
       - run:
           name: Set Up Container
           command: |
-            apt-get update && apt-get install openssh-client python-catkin-tools build-essential curl -y
-            curl https://s3.us-east-2.amazonaws.com/astuff-common-lib/ubuntu_1604/libas-common_2.1.0-0~16.040_amd64.deb -o /tmp/libas-common.deb
-            dpkg -i /tmp/libas-common.deb
+            apt-get update -qq
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep install --from-paths . --ignore-src -y
             cd ..
@@ -61,15 +54,13 @@ jobs:
 
   lunar:
     docker:
-      - image: ros:lunar-ros-core
+      - image: autonomoustuff/docker-builds:lunar-ros-core
     steps:
       - checkout
       - run:
           name: Set Up Container
           command: |
-            apt-get update && apt-get install openssh-client python-catkin-tools build-essential curl -y
-            curl https://s3.us-east-2.amazonaws.com/astuff-common-lib/ubuntu_1604/libas-common_2.1.0-0~16.040_amd64.deb -o /tmp/libas-common.deb
-            dpkg -i /tmp/libas-common.deb
+            apt-get update -qq
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep install --from-paths . --ignore-src -y
             cd ..
@@ -89,15 +80,13 @@ jobs:
 
   melodic:
     docker:
-      - image: ros:melodic-ros-core
+      - image: autonomoustuff/docker-builds:melodic-ros-core
     steps:
       - checkout
       - run:
           name: Set Up Container
           command: |
-            apt-get update && apt-get install openssh-client python-catkin-tools build-essential curl -y
-            curl https://s3.us-east-2.amazonaws.com/astuff-common-lib/ubuntu_1604/libas-common_2.1.0-0~16.040_amd64.deb -o /tmp/libas-common.deb
-            dpkg -i /tmp/libas-common.deb
+            apt-get update -qq
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep install --from-paths . --ignore-src -y
             cd ..
@@ -115,11 +104,141 @@ jobs:
             catkin run_tests
     working_directory: ~/src
 
+  indigo_release:
+    docker:
+      - image: autonomoustuff/docker-builds:indigo-ros-core
+    steps:
+      - checkout
+      - run:
+          name: Set Up Container
+          command: |
+            apt-get update -qq && apt-get install -y dh-make python-bloom ruby
+            gem install --no-rdoc --no-ri deb-s3
+            source `find /opt/ros -name setup.bash | sort | head -1`
+            rosdep install --from-paths . --ignore-src -y
+      - run:
+          name: Build
+          command: |
+            bloom-generate rosdebian --os-name ubuntu --os-version trusty --ros-distro indigo
+            fakeroot debian/rules binary
+      - run:
+          name: Upload
+          command: |
+            cd ..
+            deb-s3 upload -b autonomoustuff-repo -c trusty --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+    working_directory: ~/src
+
+  kinetic_release:
+    docker:
+      - image: autonomoustuff/docker-builds:kinetic-ros-base
+    steps:
+      - checkout
+      - run:
+          name: Set Up Container
+          command: |
+            apt-get update -qq && apt-get install -y dh-make python-bloom ruby
+            gem install --no-rdoc --no-ri deb-s3
+            source `find /opt/ros -name setup.bash | sort | head -1`
+            rosdep install --from-paths . --ignore-src -y
+      - run:
+          name: Build
+          command: |
+            bloom-generate rosdebian --os-name ubuntu --os-version xenial --ros-distro kinetic
+            fakeroot debian/rules binary
+      - run:
+          name: Upload
+          command: |
+            cd ..
+            deb-s3 upload -b autonomoustuff-repo -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+    working_directory: ~/src
+
+  lunar_release:
+    docker:
+      - image: autonomoustuff/docker-builds:lunar-ros-base
+    steps:
+      - checkout
+      - run:
+          name: Set Up Container
+          command: |
+            apt-get update -qq && apt-get install -y dh-make python-bloom ruby
+            gem install --no-rdoc --no-ri deb-s3
+            source `find /opt/ros -name setup.bash | sort | head -1`
+            rosdep install --from-paths . --ignore-src -y
+      - run:
+          name: Build
+          command: |
+            bloom-generate rosdebian --os-name ubuntu --os-version xenial --ros-distro lunar
+            fakeroot debian/rules binary
+      - run:
+          name: Upload
+          command: |
+            cd ..
+            deb-s3 upload -b autonomoustuff-repo -c xenial --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+    working_directory: ~/src
+
+  melodic_release:
+    docker:
+      - image: autonomoustuff/docker-builds:melodic-ros-base
+    steps:
+      - checkout
+      - run:
+          name: Set Up Container
+          command: |
+            apt-get update -qq && apt-get install -y dh-make python-bloom ruby
+            gem install --no-rdoc --no-ri deb-s3
+            source `find /opt/ros -name setup.bash | sort | head -1`
+            rosdep install --from-paths . --ignore-src -y
+      - run:
+          name: Build
+          command: |
+            bloom-generate rosdebian --os-name ubuntu --os-version bionic --ros-distro melodic
+            fakeroot debian/rules binary
+      - run:
+          name: Upload
+          command: |
+            cd ..
+            deb-s3 upload -b autonomoustuff-repo -c bionic --preserve-versions $(ls *.deb) --access-key-id=$S3_ACCESS_KEY_ID --secret-access-key=$S3_SECRET_ACCESS_KEY
+    working_directory: ~/src
+
 workflows:
   version: 2
   ros_build:
     jobs:
-      - indigo
-      - kinetic
-      - lunar
-      - melodic
+      - indigo:
+          filter:
+            branches:
+              ignore: release
+      - kinetic:
+          filter:
+            branches:
+              ignore: release
+      - lunar:
+          filter:
+            branches:
+              ignore: release
+      - melodic:
+          filter:
+            branches:
+              ignore: release
+  ros_release:
+    jobs:
+      - indigo_release:
+          context: ubuntu-pkg-build
+          filters:
+            branches:
+              only: release
+      - kinetic_release:
+          context: ubuntu-pkg-build
+          filters:
+            branches:
+              only: release
+      - lunar_release:
+          context: ubuntu-pkg-build
+          filters:
+            branches:
+              only: release
+      - melodic_release:
+          context: ubuntu-pkg-build
+          filters:
+            branches:
+              only: release


### PR DESCRIPTION
Changes CI to use AS-generated Docker images and adds release .deb generation when pushed to the release branch.