### PR TITLE
Use joy_linux instead of joy

### DIFF
--- a/launch/ssc_joystick.launch.xml
+++ b/launch/ssc_joystick.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <group>
     <push-ros-namespace namespace="ssc"/>
-    <node pkg="joy" exec="joy_node" name="joystick">
+    <node pkg="joy_linux" exec="joy_linux_node" name="joystick">
       <remap from="/diagnostics" to="/ssc/diagnostics" />
       <param name="deadzone" value="0.01"/>
       <param name="autorepeat_rate" value="20.0"/>

--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>sensor_msgs</depend>
 
-  <exec_depend>joy</exec_depend>
+  <exec_depend>joy_linux</exec_depend>
 
   <export><build_type>ament_cmake</build_type></export>
 </package>


### PR DESCRIPTION
Resolves #47 by switching to the `joy_linux` node since it has diagnostics support.